### PR TITLE
fix: choose t3.large instance type

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd cloud9-setup-for-prototyping
 
 ## Cloud9 for Prototyping
 
-- Amazon Linux 2.x on m5.large
+- Amazon Linux 2023 on t3.large
 - Change instance volume from 10GB to 128GB
 - Update AWS CLI version from 1.x to 2.x
 - Automatic stop time minutes is 30 min

--- a/params.json
+++ b/params.json
@@ -1,7 +1,7 @@
 {
   "name": "cloud9-for-prototyping",
   "description": "Created by cloud9-setup-for-prototyping",
-  "instance_type": "t2.large",
+  "instance_type": "t3.large",
   "image_id": "amazonlinux-2023-x86_64",
   "automatic_stop_time_minutes": 30,
   "volume_size": 128,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The following modifications have been made
- t2.large -> t3.large This is more common in this generation if there is no intention.
- Docs are brought up to date. (The actual OS and instance type have been changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
